### PR TITLE
Fixes addNodes issue in newer Firefox versions

### DIFF
--- a/content_scripts/content.js
+++ b/content_scripts/content.js
@@ -201,7 +201,7 @@ const panel = {
 
 /* Add Panel to image */
 appendPanel = ( mutation ) => {
-  Array.slice( mutation.addedNodes ).forEach( ( node ) => {
+  mutation.addedNodes.forEach( ( node ) => {
     if ( node.localName === 'img' && node.offsetParent ) { // When you insert an image
 
       if ( panel.contains( node.offsetParent ) ) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "jomon",
   "description": "You can add on Amazon Pay Buttons on the existing page.",
-  "version": "1.3",
+  "version": "1.3.1",
   "applications": {
     "gecko": {
       "id":"itshige@amazon.com",


### PR DESCRIPTION
Issue resolved by removing a seemingly redundant Array.slice() in appendPanel()